### PR TITLE
Safari on OS X has issues with rendering map labels

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
 		<title>CTIP Widget</title>
 	
 	 	<link href="https://unpkg.com/leaflet@1.1.0/dist/leaflet.css" rel="stylesheet" />
-		<link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.35.1/mapbox-gl.css" rel='stylesheet' />
+		<link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.38.0/mapbox-gl.css" rel='stylesheet' />
 		<link href="../dist/jquery.ctip.widget.css" rel='stylesheet' />
 		
 		<style>


### PR DESCRIPTION
Safari on OS X did not render map labels correctly in 0.35.1, fixed in 0.38.0